### PR TITLE
added a couple things

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,15 @@
-# xcode
+# Xcode
 build/*
 *.pbxuser
+!default.pbxuser
 *.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
 *.perspectivev3
-# osx
-.DS_Store
+!default.perspectivev3
+*.xcworkspace
+!default.xcworkspace
+xcuserdata
 profile
+*.moved-aside

--- a/Classes/PullRefreshTableViewController.h
+++ b/Classes/PullRefreshTableViewController.h
@@ -50,6 +50,7 @@
 @property (nonatomic, copy) NSString *textRelease;
 @property (nonatomic, copy) NSString *textLoading;
 
+- (void)setupStrings;
 - (void)addPullToRefreshHeader;
 - (void)startLoading;
 - (void)stopLoading;

--- a/Classes/PullRefreshTableViewController.m
+++ b/Classes/PullRefreshTableViewController.m
@@ -62,12 +62,12 @@
     refreshLabel.textAlignment = UITextAlignmentCenter;
 
     refreshArrow = [[UIImageView alloc] initWithImage:[UIImage imageNamed:@"arrow.png"]];
-    refreshArrow.frame = CGRectMake((REFRESH_HEADER_HEIGHT - 27) / 2,
-                                    (REFRESH_HEADER_HEIGHT - 44) / 2,
+    refreshArrow.frame = CGRectMake(floorf((REFRESH_HEADER_HEIGHT - 27) / 2),
+                                    (floorf(REFRESH_HEADER_HEIGHT - 44) / 2),
                                     27, 44);
 
     refreshSpinner = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleGray];
-    refreshSpinner.frame = CGRectMake((REFRESH_HEADER_HEIGHT - 20) / 2, (REFRESH_HEADER_HEIGHT - 20) / 2, 20, 20);
+    refreshSpinner.frame = CGRectMake(floorf(floorf(REFRESH_HEADER_HEIGHT - 20) / 2), floorf((REFRESH_HEADER_HEIGHT - 20) / 2), 20, 20);
     refreshSpinner.hidesWhenStopped = YES;
 
     [refreshHeaderView addSubview:refreshLabel];

--- a/Classes/PullRefreshTableViewController.m
+++ b/Classes/PullRefreshTableViewController.m
@@ -38,18 +38,38 @@
 @synthesize textPull, textRelease, textLoading, refreshHeaderView, refreshLabel, refreshArrow, refreshSpinner;
 
 - (id)initWithStyle:(UITableViewStyle)style {
-    self = [super initWithStyle:style];
-    if (self != nil) {
-        textPull = [[NSString alloc] initWithString:@"Pull down to refresh..."];
-        textRelease = [[NSString alloc] initWithString:@"Release to refresh..."];
-        textLoading = [[NSString alloc] initWithString:@"Loading..."];
-    }
-    return self;
+  self = [super initWithStyle:style];
+  if (self != nil) {
+    [self setupStrings];
+  }
+  return self;
+}
+
+- (id)initWithCoder:(NSCoder *)aDecoder {
+  self = [super initWithCoder:aDecoder];
+  if (self != nil) {
+    [self setupStrings];
+  }
+  return self;
+}
+
+- (id)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil {
+  self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
+  if (self != nil) {
+    [self setupStrings];
+  }
+  return self;
 }
 
 - (void)viewDidLoad {
-    [super viewDidLoad];
-    [self addPullToRefreshHeader];
+  [super viewDidLoad];
+  [self addPullToRefreshHeader];
+}
+
+- (void)setupStrings{
+  textPull = [[NSString alloc] initWithString:@"Pull down to refresh..."];
+  textRelease = [[NSString alloc] initWithString:@"Release to refresh..."];
+  textLoading = [[NSString alloc] initWithString:@"Loading..."];
 }
 
 - (void)addPullToRefreshHeader {


### PR DESCRIPTION
Made sure the frames were never subpixel'd.

Updated the gitignore.

The strings for the header view were previously being done in initWithStyle. This isn't always called. For example, if you're initing with a nib, or if its getting unarchived FROM a nib, in the case of a typical TabBarController app. Now it happens for everything.
