### PR TITLE
Localization and Loading Header Width

### DIFF
--- a/Classes/PullRefreshTableViewController.m
+++ b/Classes/PullRefreshTableViewController.m
@@ -67,9 +67,9 @@
 }
 
 - (void)setupStrings{
-  textPull = [[NSString alloc] initWithString:@"Pull down to refresh..."];
-  textRelease = [[NSString alloc] initWithString:@"Release to refresh..."];
-  textLoading = [[NSString alloc] initWithString:@"Loading..."];
+  textPull = [[NSString alloc] initWithString:NSLocalizedString(@"Pull down to refresh...", @"Pull down to refresh...")];
+  textRelease = [[NSString alloc] initWithString:NSLocalizedString(@"Release to refresh...", @"Release to refresh...")];
+  textLoading = [[NSString alloc] initWithString:NSLocalizedString(@"Loading...", @"Loading...")];
 }
 
 - (void)addPullToRefreshHeader {

--- a/Classes/PullRefreshTableViewController.m
+++ b/Classes/PullRefreshTableViewController.m
@@ -73,11 +73,16 @@
 }
 
 - (void)addPullToRefreshHeader {
-    refreshHeaderView = [[UIView alloc] initWithFrame:CGRectMake(0, 0 - REFRESH_HEADER_HEIGHT, 320, REFRESH_HEADER_HEIGHT)];
+    
+    CGFloat tableWidth = self.tableView.frame.size.width;
+    
+    refreshHeaderView = [[UIView alloc] initWithFrame:CGRectMake(0, 0 - REFRESH_HEADER_HEIGHT, tableWidth, REFRESH_HEADER_HEIGHT)];
     refreshHeaderView.backgroundColor = [UIColor clearColor];
+    refreshHeaderView.autoresizingMask = UIViewAutoresizingFlexibleWidth;
 
-    refreshLabel = [[UILabel alloc] initWithFrame:CGRectMake(0, 0, 320, REFRESH_HEADER_HEIGHT)];
+    refreshLabel = [[UILabel alloc] initWithFrame:CGRectMake(0, 0, tableWidth, REFRESH_HEADER_HEIGHT)];
     refreshLabel.backgroundColor = [UIColor clearColor];
+    refreshLabel.autoresizingMask = UIViewAutoresizingFlexibleWidth;
     refreshLabel.font = [UIFont boldSystemFontOfSize:12.0];
     refreshLabel.textAlignment = UITextAlignmentCenter;
 


### PR DESCRIPTION
1. Localization of the strings. 
2. The header view had a fixed width of 320 points. I've refactored this so now its width equals to the width of the table. This was bad when using the class on iPad or on iPhone in landscape position: the label wasn't centered and the view looked truncated if a color was used. It should now display properly on any table width.
   I also added Fixed Width Autoresizing masks to the view and to the label, so resizing on rotations is also covered now. 
