### PR TITLE
Updated animations to use blocks introduced in iOS 4

### DIFF
--- a/Classes/PullRefreshTableViewController.m
+++ b/Classes/PullRefreshTableViewController.m
@@ -101,32 +101,21 @@
     isDragging = YES;
 }
 
-- (void)scrollViewDidScroll:(UIScrollView *)scrollView 
-{
-    if (isLoading) 
-    {
+- (void)scrollViewDidScroll:(UIScrollView *)scrollView {
+    if (isLoading) {
         // Update the content inset, good for section headers
         if (scrollView.contentOffset.y > 0)
-        {
             self.tableView.contentInset = UIEdgeInsetsZero;
-        }
         else if (scrollView.contentOffset.y >= -REFRESH_HEADER_HEIGHT)
-        {
             self.tableView.contentInset = UIEdgeInsetsMake(-scrollView.contentOffset.y, 0, 0, 0);
-        }
-    } 
-    else if (isDragging && scrollView.contentOffset.y < 0) 
-    {
+    } else if (isDragging && scrollView.contentOffset.y < 0) {
         // Update the arrow direction and label
         [UIView animateWithDuration:0.25 animations:^{
-            if (scrollView.contentOffset.y < -REFRESH_HEADER_HEIGHT) 
-            {
+            if (scrollView.contentOffset.y < -REFRESH_HEADER_HEIGHT) {
                 // User is scrolling above the header
                 refreshLabel.text = self.textRelease;
                 [refreshArrow layer].transform = CATransform3DMakeRotation(M_PI, 0, 0, 1);
-            } 
-            else 
-            { 
+            } else { 
                 // User is scrolling somewhere within the header
                 refreshLabel.text = self.textPull;
                 [refreshArrow layer].transform = CATransform3DMakeRotation(M_PI * 2, 0, 0, 1);
@@ -144,8 +133,7 @@
     }
 }
 
-- (void)startLoading 
-{
+- (void)startLoading {
     isLoading = YES;
     
     // Show the header
@@ -160,8 +148,7 @@
     [self refresh];
 }
 
-- (void)stopLoading 
-{
+- (void)stopLoading {
     isLoading = NO;
     
     // Hide the header

--- a/Classes/PullRefreshTableViewController.m
+++ b/Classes/PullRefreshTableViewController.m
@@ -101,25 +101,37 @@
     isDragging = YES;
 }
 
-- (void)scrollViewDidScroll:(UIScrollView *)scrollView {
-    if (isLoading) {
+- (void)scrollViewDidScroll:(UIScrollView *)scrollView 
+{
+    if (isLoading) 
+    {
         // Update the content inset, good for section headers
         if (scrollView.contentOffset.y > 0)
+        {
             self.tableView.contentInset = UIEdgeInsetsZero;
-        else if (scrollView.contentOffset.y >= -REFRESH_HEADER_HEIGHT)
-            self.tableView.contentInset = UIEdgeInsetsMake(-scrollView.contentOffset.y, 0, 0, 0);
-    } else if (isDragging && scrollView.contentOffset.y < 0) {
-        // Update the arrow direction and label
-        [UIView beginAnimations:nil context:NULL];
-        if (scrollView.contentOffset.y < -REFRESH_HEADER_HEIGHT) {
-            // User is scrolling above the header
-            refreshLabel.text = self.textRelease;
-            [refreshArrow layer].transform = CATransform3DMakeRotation(M_PI, 0, 0, 1);
-        } else { // User is scrolling somewhere within the header
-            refreshLabel.text = self.textPull;
-            [refreshArrow layer].transform = CATransform3DMakeRotation(M_PI * 2, 0, 0, 1);
         }
-        [UIView commitAnimations];
+        else if (scrollView.contentOffset.y >= -REFRESH_HEADER_HEIGHT)
+        {
+            self.tableView.contentInset = UIEdgeInsetsMake(-scrollView.contentOffset.y, 0, 0, 0);
+        }
+    } 
+    else if (isDragging && scrollView.contentOffset.y < 0) 
+    {
+        // Update the arrow direction and label
+        [UIView animateWithDuration:0.25 animations:^{
+            if (scrollView.contentOffset.y < -REFRESH_HEADER_HEIGHT) 
+            {
+                // User is scrolling above the header
+                refreshLabel.text = self.textRelease;
+                [refreshArrow layer].transform = CATransform3DMakeRotation(M_PI, 0, 0, 1);
+            } 
+            else 
+            { 
+                // User is scrolling somewhere within the header
+                refreshLabel.text = self.textPull;
+                [refreshArrow layer].transform = CATransform3DMakeRotation(M_PI * 2, 0, 0, 1);
+            }
+        }];
     }
 }
 
@@ -132,36 +144,34 @@
     }
 }
 
-- (void)startLoading {
+- (void)startLoading 
+{
     isLoading = YES;
-
+    
     // Show the header
-    [UIView beginAnimations:nil context:NULL];
-    [UIView setAnimationDuration:0.3];
-    self.tableView.contentInset = UIEdgeInsetsMake(REFRESH_HEADER_HEIGHT, 0, 0, 0);
-    refreshLabel.text = self.textLoading;
-    refreshArrow.hidden = YES;
-    [refreshSpinner startAnimating];
-    [UIView commitAnimations];
-
+    [UIView animateWithDuration:0.3 animations:^{
+        self.tableView.contentInset = UIEdgeInsetsMake(REFRESH_HEADER_HEIGHT, 0, 0, 0);
+        refreshLabel.text = self.textLoading;
+        refreshArrow.hidden = YES;
+        [refreshSpinner startAnimating];
+    }];
+    
     // Refresh action!
     [self refresh];
 }
 
-- (void)stopLoading {
+- (void)stopLoading 
+{
     isLoading = NO;
-
+    
     // Hide the header
-    [UIView beginAnimations:nil context:NULL];
-    [UIView setAnimationDelegate:self];
-    [UIView setAnimationDuration:0.3];
-    [UIView setAnimationDidStopSelector:@selector(stopLoadingComplete:finished:context:)];
-    self.tableView.contentInset = UIEdgeInsetsZero;
-    UIEdgeInsets tableContentInset = self.tableView.contentInset;
-    tableContentInset.top = 0.0;
-    self.tableView.contentInset = tableContentInset;
-    [refreshArrow layer].transform = CATransform3DMakeRotation(M_PI * 2, 0, 0, 1);
-    [UIView commitAnimations];
+    [UIView animateWithDuration:0.3 animations:^{
+        self.tableView.contentInset = UIEdgeInsetsZero;
+        [refreshArrow layer].transform = CATransform3DMakeRotation(M_PI * 2, 0, 0, 1);
+    } 
+                     completion:^(BOOL finished) {
+                         [self performSelector:@selector(stopLoadingComplete:finished:context:)];
+                     }];
 }
 
 - (void)stopLoadingComplete:(NSString *)animationID finished:(NSNumber *)finished context:(void *)context {


### PR DESCRIPTION
Updated PullRefreshTableViewController.m to use the new style animations introduced in iOS4. Per the Apple documents on UIView, use of the old style animations is discouraged in iOS 4 and later and they suggest using block-based animation methods instead.
