### PR TITLE
trivial but very visible typo ("intall" vs "install") in README.markdown

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -11,7 +11,7 @@ Inspired by [Tweetie 2](http://www.atebits.com/tweetie-iphone/), [Oliver Drobnik
 and [EGOTableViewPullRefresh](http://github.com/enormego/EGOTableViewPullRefresh).
 
 
-How to intall
+How to install
 
 1. Copy the files, [PullRefreshTableViewController.h](https://raw.github.com/leah/PullToRefresh/master/Classes/PullRefreshTableViewController.h),
 [PullRefreshTableViewController.m](https://raw.github.com/leah/PullToRefresh/master/Classes/PullRefreshTableViewController.m),


### PR DESCRIPTION
title and commit comment contents say it all:  one character typo, but it's pretty much the first thing anyone downloading this project sees.  sorry to be pedantic … i misspell enough stuff myself, so i hope this helps.
