### PR TITLE
#defines for use with feature obj_arc + protocol for more MVC-like behavior

### DIFF
--- a/Classes/DemoTableViewController.m
+++ b/Classes/DemoTableViewController.m
@@ -8,11 +8,13 @@
 
 #import "DemoTableViewController.h"
 
+@interface DemoTableViewController () <PullRefreshTableViewDelegate>
 
 @implementation DemoTableViewController
 
 - (void)viewDidLoad {
     [super viewDidLoad];
+	self.refreshDelegate = self;
 
     self.title = @"Pull to Refresh";
     items = [[NSMutableArray alloc] initWithObjects:@"What time is it?", nil];
@@ -39,6 +41,9 @@
 
     return cell;
 }
+
+#pragma mark - PullRefreshTableViewDelegate implementation
+#pragma mark @required
 
 - (void)refresh {
     [self performSelector:@selector(addItem) withObject:nil afterDelay:2.0];

--- a/Classes/PullRefreshTableViewController.h
+++ b/Classes/PullRefreshTableViewController.h
@@ -29,6 +29,9 @@
 
 #import <UIKit/UIKit.h>
 
+@protocol PullRefreshTableViewDelegate
+- (void)refresh;
+@end
 
 @interface PullRefreshTableViewController : UITableViewController {
     UIView *refreshHeaderView;
@@ -42,10 +45,29 @@
     NSString *textLoading;
 }
 
-@property (nonatomic, retain) UIView *refreshHeaderView;
-@property (nonatomic, retain) UILabel *refreshLabel;
-@property (nonatomic, retain) UIImageView *refreshArrow;
-@property (nonatomic, retain) UIActivityIndicatorView *refreshSpinner;
+#ifndef PTR_STRONG
+#if __has_feature(objc_arc)
+#define PTR_STRONG strong
+#else
+#define PTR_STRONG retain
+#endif
+#endif
+
+#ifndef PTR_WEAK
+#if __has_feature(objc_arc_weak)
+#define PTR_WEAK weak
+#elif __has_feature(objc_arc)
+#define PTR_WEAK unsafe_unretained
+#else
+#define PTR_WEAK assign
+#endif
+#endif
+
+@property (nonatomic, PTR_WEAK) id<PullRefreshTableViewDelegate> refreshDelegate;
+@property (nonatomic, PTR_STRONG) UIView *refreshHeaderView;
+@property (nonatomic, PTR_STRONG) UILabel *refreshLabel;
+@property (nonatomic, PTR_STRONG) UIImageView *refreshArrow;
+@property (nonatomic, PTR_STRONG) UIActivityIndicatorView *refreshSpinner;
 @property (nonatomic, copy) NSString *textPull;
 @property (nonatomic, copy) NSString *textRelease;
 @property (nonatomic, copy) NSString *textLoading;
@@ -54,6 +76,5 @@
 - (void)addPullToRefreshHeader;
 - (void)startLoading;
 - (void)stopLoading;
-- (void)refresh;
 
 @end

--- a/Classes/PullRefreshTableViewController.m
+++ b/Classes/PullRefreshTableViewController.m
@@ -35,7 +35,7 @@
 
 @implementation PullRefreshTableViewController
 
-@synthesize textPull, textRelease, textLoading, refreshHeaderView, refreshLabel, refreshArrow, refreshSpinner;
+@synthesize textPull, textRelease, textLoading, refreshDelegate, refreshHeaderView, refreshLabel, refreshArrow, refreshSpinner;
 
 - (id)initWithStyle:(UITableViewStyle)style {
   self = [super initWithStyle:style];
@@ -67,9 +67,9 @@
 }
 
 - (void)setupStrings{
-  textPull = [[NSString alloc] initWithString:@"Pull down to refresh..."];
-  textRelease = [[NSString alloc] initWithString:@"Release to refresh..."];
-  textLoading = [[NSString alloc] initWithString:@"Loading..."];
+  textPull = NSLocalizedString(@"Pull down to refresh...", nil);
+  textRelease = NSLocalizedString(@"Release to refresh...", nil);
+  textLoading = NSLocalizedString(@"Loading...", nil);
 }
 
 - (void)addPullToRefreshHeader {
@@ -145,7 +145,7 @@
     }];
     
     // Refresh action!
-    [self refresh];
+    [self.refreshDelegate refresh];
 }
 
 - (void)stopLoading {
@@ -168,12 +168,15 @@
     [refreshSpinner stopAnimating];
 }
 
+/*
 - (void)refresh {
     // This is just a demo. Override this method with your custom reload action.
     // Don't forget to call stopLoading at the end.
     [self performSelector:@selector(stopLoading) withObject:nil afterDelay:2.0];
 }
+*/
 
+#if !__has_feature(objc_arc)
 - (void)dealloc {
     [refreshHeaderView release];
     [refreshLabel release];
@@ -184,5 +187,6 @@
     [textLoading release];
     [super dealloc];
 }
+#endif
 
 @end


### PR DESCRIPTION
some suggested fixes for use with projects that use ARC

1) in the vein of github/jdg/MBProgressHUD.git, add #defines for
   _STRONG and _WEAK so this can be used for both older non-arc and newer
   arc-based projects
2) add @protocol PullToRefreshTableViewDelegate to force the implementor
   to implement their own refresh

also
a) silence "redundant" Xcode 4.4 clang warnings in setupStrings by
   using the suggested fixes for the strings
b) also, localize the strings so a project can decide to set these
   values to whatever makes most sense to the project, and the most
   sense for each localization
c) show how the protocol works in the DemoTableViewController.m
